### PR TITLE
Include all_attributes when starting syncs.

### DIFF
--- a/lib/trogdir/versions/v1/entities/sync_log_with_changeset.rb
+++ b/lib/trogdir/versions/v1/entities/sync_log_with_changeset.rb
@@ -8,6 +8,7 @@ module Trogdir
       expose(:scope) { |sync_log| sync_log.changeset.scope }
       expose(:original) { |sync_log| sync_log.changeset.original }
       expose(:modified) { |sync_log| sync_log.changeset.modified }
+      expose(:all_attributes) { |sync_log| sync_log.changeset.trackable.attributes }
       expose(:created_at) { |sync_log| sync_log.changeset.created_at }
     end
   end

--- a/spec/api/change_syncs_spec.rb
+++ b/spec/api/change_syncs_spec.rb
@@ -47,6 +47,7 @@ describe Trogdir::API do
           expect(json.first['scope']).to eql 'person'
           expect(json.first['original']).to eql({})
           expect(json.first['modified']).to be_a Hash
+          expect(json.first['all_attributes']).to be_a Hash
           expect(json.first).to have_key 'created_at'
         end
 


### PR DESCRIPTION
This comes in handly when needing a little more context information without having to make a separate request to the API.