### PR TITLE
Upgrade trogdir models gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'newrelic_rpm'
 gem 'oj'
 gem 'pinglish'
 gem 'rake'
-gem 'trogdir_models','>= 0.11.1'
+gem 'trogdir_models','>= 0.12.1'
 gem 'turnout'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,5 +186,5 @@ DEPENDENCIES
   rspec
   rspec-its
   shotgun
-  trogdir_models (>= 0.11.1)
+  trogdir_models (>= 0.12.1)
   turnout


### PR DESCRIPTION
This is for allowing entitlements and affiliations to be created as a
blank array instead of nil.